### PR TITLE
Abstract Grader site created, added to sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,10 @@ def organizer():
 def dashboard():
     return render_template('dashboard.html')
 
+@app.route('/abstractGrader')
+def abstractGrader():
+    return render_template('abstractGrader.html')
+
 @app.route('/schedule')
 def schedule():
     return render_template('organizer.html')

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -15,11 +15,13 @@
     </a>
 
     <div class="mt-3 mb-2 text-uppercase text-xs opacity-6" style="padding-left:6px;">Quick Links</div>
-    <a class="btn btn-outline-secondary mb-2 nav-link" href="https://github.com/" target="_blank" rel="noopener">
+    <a class="btn btn-outline-secondary mb-2 nav-link" href="https://github.com/" rel="noopener">
       <span class="icon">📆</span><span class="label">Program</span>
     </a>
-    <a class="btn btn-outline-secondary mb-2 nav-link" href="https://developer.mozilla.org/" target="_blank" rel="noopener">
-      <span class="icon">✅</span><span class="label">Grading</span>
+    <a class="btn btn-outline-secondary mb-2 nav-link" href="abstractGrader"  rel="noopener">
+      <span class="icon">✅</span><span class="label">Abstract Grading</span>
+    </a>
+    
     </a>
     <a class="btn btn-outline-secondary mb-2 nav-link" href="https://www.youtube.com/" target="_blank" rel="noopener">
       <span class="icon">▶️</span><span class="label">??</span>

--- a/templates/abstractGrader.html
+++ b/templates/abstractGrader.html
@@ -1,0 +1,360 @@
+{% extends "base.html" %}
+
+{% block title %}Abstract Grader Dashboard{% endblock %}
+
+{% block content %}
+
+
+<div class="d-flex align-items-center justify-content-between flex-wrap gap-3 mb-4">
+  <div>
+    <h2 class="mb-1">Abstract Grader Dashboard</h2>
+    <p class="text-secondary mb-0">Review, score, and track abstracts quickly.</p>
+  </div>
+
+  <div class="d-flex align-items-center gap-3">
+    <div class="input-group">
+      <span class="input-group-text bg-gray-100 text-secondary">Due</span>
+      <input type="date" class="form-control" id="dueDate">
+    </div>
+
+    <div class="text-end">
+      <small class="text-secondary d-block" id="progressLabel">0% complete</small>
+      <div class="progress" style="width:220px;height:6px;">
+        <div class="progress-bar" id="progressBar" role="progressbar" style="width:0%"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Tools -->
+<div class="row g-3 mb-4">
+  <div class="col-12 col-lg-6">
+    <div class="input-group">
+      <span class="input-group-text bg-gray-100"><i class="fas fa-search"></i></span>
+      <input type="text" class="form-control" id="searchInput" placeholder="Search by abstract title or author">
+    </div>
+  </div>
+
+  <div class="col-12 col-lg-6">
+    <div class="d-flex flex-wrap gap-2 justify-content-lg-end">
+      <button class="btn btn-sm btn-outline-secondary active" data-filter="all">All</button>
+      <button class="btn btn-sm btn-outline-secondary" data-filter="todo">To Do</button>
+      <button class="btn btn-sm btn-outline-secondary" data-filter="done">Completed</button>
+      <div class="dropdown">
+        <button class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">Track</button>
+        <ul class="dropdown-menu dropdown-menu-end" id="trackFilter">
+          <li><a class="dropdown-item" data-track="">All</a></li>
+          <li><a class="dropdown-item" data-track="Systems">Systems</a></li>
+          <li><a class="dropdown-item" data-track="Oceans">Oceans</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- To Do  -->
+{# Build a clean list of todos first #}
+{% set todos = abstracts|selectattr('status','equalto','todo')|list %}
+<h5 class="mt-5 mb-3">To Do</h5>
+<div class="row g-4 row-cols-1 row-cols-md-2" id="todoGrid">
+  {% for a in todos %}
+  <div class="col abstract-card" data-card data-status="todo"
+       data-title="{{ a.title|lower }}"
+       data-authors="{{ a.authors|lower }}"
+       data-authors-list="{{ (a.authors_list|default([]))|join('|') }}"
+       data-track="{{ a.track|lower }}">
+    <div class="card shadow-xs border-0 rounded-4 h-100">
+      <div class="card-body d-flex gap-3">
+        <div class="d-flex flex-column align-items-center pt-1">
+          <button class="btn btn-outline-secondary rounded-circle p-0 status-toggle"
+                  style="width:36px;height:36px" aria-pressed="false" title="Mark as completed">
+            <i class="far fa-circle"></i>
+          </button>
+        </div>
+
+        <img class="rounded-3 shadow-sm flex-shrink-0" style="width:84px;height:84px;object-fit:cover;"
+             src="{{ a.thumbnail_url or url_for('static', filename='images/abstract-thumb.png') }}"
+             alt="thumbnail">
+
+        <div class="flex-grow-1">
+          <div class="d-flex justify-content-between align-items-start">
+            <h6 class="mb-1">{{ a.title }}</h6>
+            <span class="badge bg-gray-100 text-secondary">{{ a.time_submitted or 'Just now' }}</span>
+          </div>
+          <p class="text-sm text-secondary mb-1">{{ a.authors }}</p>
+          <p class="text-sm mb-2">{{ a.summary }}</p>
+          <div class="d-flex align-items-center gap-2">
+            <span class="badge bg-info text-white">{{ a.track or 'General' }}</span>
+            <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#gradeModal" data-id="{{ a.id }}">Grade</button>
+            <a class="btn btn-sm btn-outline-secondary" href="javascript:;">View</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+
+  {% if todos|length == 0 %}
+  {# ——— Placeholders if there are no To-Do items ——— #}
+  <div class="col abstract-card" data-card data-status="todo"
+       data-title="ai for ocean sensors"
+       data-authors="ada lovelace; alan turing"
+       data-authors-list="ada lovelace|alan turing"
+       data-track="systems">
+    <div class="card shadow-xs border-0 rounded-4 h-100">
+      <div class="card-body d-flex gap-3">
+        <div class="d-flex flex-column align-items-center pt-1">
+          <button class="btn btn-outline-secondary rounded-circle p-0 status-toggle"
+                  style="width:36px;height:36px" aria-pressed="false" title="Mark as completed">
+            <i class="far fa-circle"></i>
+          </button>
+        </div>
+        <img class="rounded-3 shadow-sm flex-shrink-0" style="width:84px;height:84px;object-fit:cover;"
+             src="{{ url_for('static', filename='images/abstract-thumb.png') }}" alt="thumb">
+        <div class="flex-grow-1">
+          <h6 class="mb-1">AI for Ocean Sensors</h6>
+          <p class="text-sm text-secondary mb-1">Ada Lovelace; Alan Turing</p>
+          <p class="text-sm mb-2">Learning-based drift correction for submerged sensor arrays…</p>
+          <div class="d-flex align-items-center gap-2">
+            <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#gradeModal">Grade</button>
+            <a class="btn btn-sm btn-outline-secondary" href="javascript:;">View</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col abstract-card" data-card data-status="todo"
+       data-title="satellite data fusion"
+       data-authors="katherine johnson; grace hopper"
+       data-authors-list="katherine johnson|grace hopper"
+       data-track="oceans">
+    <div class="card shadow-xs border-0 rounded-4 h-100">
+      <div class="card-body d-flex gap-3">
+        <div class="d-flex flex-column align-items-center pt-1">
+          <button class="btn btn-outline-secondary rounded-circle p-0 status-toggle"
+                  style="width:36px;height:36px" aria-pressed="false" title="Mark as completed">
+            <i class="far fa-circle"></i>
+          </button>
+        </div>
+        <img class="rounded-3 shadow-sm flex-shrink-0" style="width:84px;height:84px;object-fit:cover;"
+             src="{{ url_for('static', filename='images/abstract-thumb.png') }}" alt="thumb">
+        <div class="flex-grow-1">
+          <h6 class="mb-1">Satellite Data Fusion</h6>
+          <p class="text-sm text-secondary mb-1">Katherine Johnson; Grace Hopper</p>
+          <p class="text-sm mb-2">Combining SAR and multispectral signals for coastal change…</p>
+          <div class="d-flex align-items-center gap-2">
+            <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#gradeModal">Grade</button>
+            <a class="btn btn-sm btn-outline-secondary" href="javascript:;">View</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+</div>
+
+
+<!-- Completed -->
+<h5 class="mt-5 mb-3">Completed</h5>
+<div class="row g-4 row-cols-1 row-cols-md-2" id="completedGrid">
+  {% for a in abstracts if a.status == "done" %}
+  <div class="col abstract-card" data-card  data-status="done"
+       data-title="{{ a.title|lower }}" data-authors="{{ a.authors|lower }}" data-track="{{ a.track|lower }}">
+    <div class="card shadow-xs border-0 rounded-4 h-100">
+      <div class="card-body d-flex gap-3 opacity-85">
+        <div class="d-flex flex-column align-items-center pt-1">
+          <span class="btn btn-success rounded-circle p-0" style="width:36px;height:36px"><i class="fas fa-check"></i></span>
+        </div>
+        <img class="rounded-3 shadow-sm flex-shrink-0" style="width:84px;height:84px;object-fit:cover;"
+             src="{{ a.thumbnail_url or url_for('static', filename='images/abstract-thumb.png') }}"
+             alt="thumb">
+        <div class="flex-grow-1">
+          <div class="d-flex justify-content-between align-items-start">
+            <h6 class="mb-1">{{ a.title }}</h6>
+            <span class="badge bg-gray-100 text-secondary">Score: {{ a.score or '—' }}</span>
+          </div>
+          <p class="text-sm text-secondary mb-1">{{ a.authors }}</p>
+          <p class="text-sm mb-2">{{ a.summary }}</p>
+          <div class="d-flex align-items-center gap-2">
+            <span class="badge bg-success">Graded</span>
+            <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#gradeModal" data-id="{{ a.id }}">Edit grade</button>
+            <button class="btn btn-sm btn-link text-danger p-0 ms-auto undo-done" data-id="{{ a.id }}">Undo</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+<!-- Grade Modal -->
+<div class="modal fade" id="gradeModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content rounded-4">
+      <div class="modal-header">
+        <h6 class="modal-title">Grade Abstract</h6>
+        <button class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form id="gradeForm">
+        <div class="modal-body">
+          <div class="row g-3">
+            <div class="col-12 col-md-8">
+              <label class="form-label">Comments to authors</label>
+              <textarea class="form-control" rows="5" placeholder="Constructive comments…"></textarea>
+            </div>
+            <div class="col-12 col-md-4">
+              <label class="form-label">Criteria</label>
+
+              <div class="mb-3">
+                <label class="form-label d-flex justify-content-between"><span>Originality</span><span id="scoreOrigVal">3</span></label>
+                <input type="range" class="form-range crit" min="1" max="5" value="3" id="scoreOrig">
+              </div>
+
+              <div class="mb-3">
+                <label class="form-label d-flex justify-content-between"><span>Clarity</span><span id="scoreClarVal">3</span></label>
+                <input type="range" class="form-range crit" min="1" max="5" value="3" id="scoreClar">
+              </div>
+
+              <div class="mb-3">
+                <label class="form-label d-flex justify-content-between"><span>Significance</span><span id="scoreSignVal">3</span></label>
+                <input type="range" class="form-range crit" min="1" max="5" value="3" id="scoreSign">
+              </div>
+
+              <div class="border rounded-3 p-2 text-center">
+                <div class="small text-secondary">Total</div>
+                <div class="fs-4 fw-bold" id="scoreTotal">9</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button class="btn btn-info" type="submit">Save grade</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    const todoGrid = document.getElementById('todoGrid');
+    const completedGrid = document.getElementById('completedGrid');
+    const searchInput = document.getElementById('searchInput');
+    const trackMenu = document.getElementById('trackFilter');
+    const statusButtons = document.querySelectorAll('[data-filter]');
+  
+    // current filter state
+    let statusFilter = 'all';   // 'all' | 'todo' | 'done'
+    let trackFilter = '';       // '' or a track (lowercased)
+    let query = '';             // lowercased search string
+  
+    function updateProgress() {
+      const cards = Array.from(document.querySelectorAll('[data-card]'));
+      const total = cards.length;
+      const done  = cards.filter(c => c.dataset.status === 'done').length;
+      const pct   = total ? Math.round(done / total * 100) : 0;
+      const bar   = document.getElementById('progressBar');
+      const lbl   = document.getElementById('progressLabel');
+      if (bar) bar.style.width = pct + '%';
+      if (lbl) lbl.textContent = `${pct}% complete · ${done}/${total}`;
+    }
+  
+    function matchesQuery(card) {
+      if (!query) return true;
+      const t = (card.dataset.title || '').toLowerCase();
+      const a = (card.dataset.authors || '').toLowerCase();
+      const r = (card.dataset.track || '').toLowerCase();
+      return (t.includes(query) || a.includes(query) || r.includes(query));
+    }
+  
+    function matchesStatus(card) {
+      return statusFilter === 'all' || (card.dataset.status === statusFilter);
+    }
+  
+    function matchesTrack(card) {
+      if (!trackFilter) return true;
+      return (card.dataset.track || '').toLowerCase() === trackFilter;
+    }
+  
+    function applyFilters() {
+      document.querySelectorAll('[data-card]').forEach(card => {
+        const show = matchesStatus(card) && matchesTrack(card) && matchesQuery(card);
+        card.style.display = show ? '' : 'none';
+      });
+    }
+  
+    // Search: live filter
+    searchInput.addEventListener('input', () => {
+      query = searchInput.value.trim().toLowerCase();
+      applyFilters();
+    });
+  
+    // Status buttons (All / To Do / Completed)
+    statusButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        statusButtons.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        statusFilter = btn.getAttribute('data-filter'); // all | todo | done
+        applyFilters();
+      });
+    });
+  
+    // Track dropdown (click on <a data-track="...">)
+    trackMenu.addEventListener('click', (e) => {
+      const item = e.target.closest('[data-track]');
+      if (!item) return;
+      trackFilter = (item.getAttribute('data-track') || '').toLowerCase();
+      applyFilters();
+    });
+  
+    // Toggle circle: move only the clicked card between grids
+    document.addEventListener('click', (e) => {
+      const btn = e.target.closest('.status-toggle');
+      if (!btn) return;
+  
+      const col = btn.closest('[data-card]'); // the single card column
+      if (!col) return;
+  
+      const isDone = col.dataset.status === 'done';
+  
+      if (isDone) {
+        // move back to To-Do
+        col.dataset.status = 'todo';
+        btn.classList.remove('btn-success');
+        btn.classList.add('btn-outline-secondary');
+        btn.setAttribute('aria-pressed', 'false');
+        btn.title = 'Mark as completed';
+        btn.innerHTML = '<i class="far fa-circle"></i>';
+        todoGrid.append(col);
+      } else {
+        // move to Completed
+        col.dataset.status = 'done';
+        btn.classList.remove('btn-outline-secondary');
+        btn.classList.add('btn-success');
+        btn.setAttribute('aria-pressed', 'true');
+        btn.title = 'Move back to To-Do';
+        btn.innerHTML = '<i class="fas fa-check"></i>';
+        completedGrid.append(col);
+      }
+  
+      updateProgress();
+      applyFilters(); // re-apply search & filters so the moved item respects current view
+    });
+  
+    // init
+    updateProgress();
+    applyFilters();
+  })();
+  </script>
+  
+
+
+<style>
+  .opacity-85 { opacity: .85; }
+  .card .badge.bg-gray-100 { background: #f6f9fc !important; }
+  .move-on-hover:hover { transform: translateY(-2px); transition: .2s ease; }
+</style>
+
+{% endblock %}


### PR DESCRIPTION
The main goal of this branch was to create a abstract grader page. When the abstract grader button is pressed in the sidebar, we are redirected to a sample abstract grading page

- Created abstractGrader.html in templates
- made edits to app.py and _sidebar.html in order to utilize dashboard
- run using python3 app.py
- Able to search for abstracts using title or author names(primary or secondary works)
- Able to mark abstracts as completed by pressing the circle on the top left of each abstract card, and then abstracts will move to Completed. Can be unselected to move back into todo